### PR TITLE
The list of organization inside "Manage Organizations" now refreshes

### DIFF
--- a/app/src/main/java/no/ntnu/klubbhuset/ui/managerviews/ManagerViewModel.java
+++ b/app/src/main/java/no/ntnu/klubbhuset/ui/managerviews/ManagerViewModel.java
@@ -56,8 +56,8 @@ public class ManagerViewModel extends AndroidViewModel {
     public LiveData<List<Club>> getManagedClubs() {
         if (clubs == null) {
             clubs = new MutableLiveData<>();
-            loadManagedClubs();
         }
+        loadManagedClubs();
         return clubs;
     }
 

--- a/app/src/main/java/no/ntnu/klubbhuset/ui/managerviews/list/ManagedOrgsListFragment.java
+++ b/app/src/main/java/no/ntnu/klubbhuset/ui/managerviews/list/ManagedOrgsListFragment.java
@@ -2,10 +2,12 @@ package no.ntnu.klubbhuset.ui.managerviews.list;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProviders;
@@ -33,6 +35,7 @@ public class ManagedOrgsListFragment extends Fragment {
     private int mColumnCount = 1;
     private OnListFragmentInteractionListener mListener;
     private ManagerViewModel mViewModel;
+    private ManagedOrgsRecyclerViewAdapter adapter;
 
     /**
      * Mandatory empty constructor for the fragment manager to instantiate the
@@ -75,7 +78,8 @@ public class ManagedOrgsListFragment extends Fragment {
                 recyclerView.setLayoutManager(new GridLayoutManager(context, mColumnCount));
             }
             mViewModel.getManagedClubs().observe(this, clubs -> {
-                recyclerView.setAdapter(new ManagedOrgsRecyclerViewAdapter(clubs, mListener));
+                adapter = new ManagedOrgsRecyclerViewAdapter(clubs, mListener);
+                recyclerView.setAdapter(adapter);
             });
         }
         return view;
@@ -117,5 +121,15 @@ public class ManagedOrgsListFragment extends Fragment {
     public interface OnListFragmentInteractionListener {
         // TODO: Update argument type and name
         void onListFragmentInteraction(Club item);
+    }
+
+    @Override
+    public void onInflate(@NonNull Context context, @NonNull AttributeSet attrs, @Nullable Bundle savedInstanceState) {
+        super.onInflate(context, attrs, savedInstanceState);
+        if (adapter != null) {
+            mViewModel.getManagedClubs().observe(this, clubs -> {
+                adapter.notifyDataSetChanged();
+            });
+        }
     }
 }


### PR DESCRIPTION
The list of organization inside "Manage Organizations" now refreshes the list of orgs every time we inflate the fragment. This way the list gets fresh updates from server when we create a new org.

Closes #89 